### PR TITLE
Added newer versions of chromedriver, googlechrome and ie11webdriver

### DIFF
--- a/chromedriver-86.json
+++ b/chromedriver-86.json
@@ -1,0 +1,17 @@
+{
+    "version": "86.0.4240.22",
+    "homepage": "https://chromedriver.chromium.org/",
+    "description": "An open source tool for automated testing of webapps across many browsers",
+    "license": "BSD-3-Clause",
+    "url": "https://chromedriver.storage.googleapis.com/86.0.4240.22/chromedriver_win32.zip",
+    "hash": "md5:bfbb2a4b657284571b390002086b5eb3",
+    "bin": "chromedriver.exe",
+    "checkver": "stable.*?([\\d.]+)<",
+    "autoupdate": {
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+        "hash": {
+            "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+            "regex": "$version/$basename.*?\"$md5\""
+        }
+    }
+}

--- a/googlechrome-86.json
+++ b/googlechrome-86.json
@@ -1,0 +1,51 @@
+{
+    "version": "86.0.4240.111",
+    "description": "Fast, secure, and free web browser, built for the modern web.",
+    "homepage": "https://www.google.com/chrome/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.google.com/chrome/privacy/eula_text.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dl.google.com/release2/chrome/HVYtPXYu8Dq4OLXyj8TJOQ_86.0.4240.111/86.0.4240.111_chrome_installer.exe#/dl.7z",
+            "hash": "79d7ddcf0d93ce1052e32239b8964073917f016f007ff57e9a3ac60c6f743c90"
+        },
+        "32bit": {
+            "url": "https://dl.google.com/release2/chrome/Tc7NMQpovp2oXhH4Gf9Tpg_86.0.4240.111/86.0.4240.111_chrome_installer.exe#/dl.7z",
+            "hash": "bf63ed58ef52b063aa62d7ef444b2ddb101e7c9b554a5285ce4cedb16c3159ee"
+        }
+    },
+    "installer": {
+        "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+    },
+    "bin": "chrome.exe",
+    "shortcuts": [
+        [
+            "chrome.exe",
+            "Google Chrome"
+        ]
+    ],
+    "checkver": {
+        "url": "https://chrome-dl.com/api/chrome.min.xml",
+        "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+                "hash": {
+                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "xpath": "/chromechecker/stable64[version='$version']/sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+                "hash": {
+                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "xpath": "/chromechecker/stable32[version='$version']/sha256"
+                }
+            }
+        }
+    }
+}

--- a/ie11webdriver-3.105.1.1.json
+++ b/ie11webdriver-3.105.1.1.json
@@ -1,0 +1,10 @@
+{
+    "version": "3.105.1.1",
+    "homepage": "http://www.seleniumhq.org/",
+    "bin": "IEDriverServer.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://raw.githubusercontent.com/SeleniumHQ/selenium/8a3022db2f5352087ee07a811f9a1f50549acaf1/cpp/prebuilt/Win32/Release/IEDriverServer.exe"
+        }
+    }
+}


### PR DESCRIPTION
This just adds new versions of the packages we use, as the current Chrome version is getting rather out of date and we need a newer IEDriverServer to work with webdriverio 6. Note that this is a prerelease version of IEDriverServer, as all other 3.x versions had broken `Content-Length` header checks.