### PR TITLE
TINY-6598: Added locked down edgedriver version

### DIFF
--- a/edgedriver-86.json
+++ b/edgedriver-86.json
@@ -1,0 +1,35 @@
+{
+    "version": "86.0.622.1",
+    "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+    "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+    },
+    "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+    "architecture": {
+        "64bit": {
+            "url": "https://msedgedriver.azureedge.net/86.0.622.1/edgedriver_win64.zip",
+            "hash": "e16b4ff7370a10a32e2f68c54f256176798643d00d6e014f1f1ba5f9290f9788"
+        },
+        "32bit": {
+            "url": "https://msedgedriver.azureedge.net/86.0.622.1/edgedriver_win32.zip",
+            "hash": "3b1aa3ec340485b75242ab72e5f8f64be1ad9bb5e606d7bc5ec9d9b585a97edc"
+        }
+    },
+    "bin": "msedgedriver.exe",
+    "checkver": {
+        "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+            },
+            "32bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
We need to use a new edgedriver for the new Chromium version of Edge, however the version in Scoop is 88 and the current version of Edge is 86. So this provides a locked-down version of the driver.

Note: The one change I made from the default version in Scoop is to change `LATEST_CANARY` to `LATEST_STABLE`.