### PR TITLE
TINY-7939: Added Google Chrome, chromedriver and edgedriver v93

### DIFF
--- a/chromedriver-93.json
+++ b/chromedriver-93.json
@@ -1,0 +1,17 @@
+{
+    "version": "93.0.4577.15",
+    "description": "An open source tool for automated testing of webapps across many browsers",
+    "homepage": "https://chromedriver.chromium.org/",
+    "license": "BSD-3-Clause",
+    "url": "https://chromedriver.storage.googleapis.com/93.0.4577.15/chromedriver_win32.zip",
+    "hash": "md5:33cd7f216b2353ad0b0a0891f52ec657",
+    "bin": "chromedriver.exe",
+    "checkver": "stable.*?([\\d.]+)<",
+    "autoupdate": {
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+        "hash": {
+            "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+            "regex": "$version/$basename.*?\"$md5\""
+        }
+    }
+}

--- a/edgedriver-93.json
+++ b/edgedriver-93.json
@@ -1,0 +1,35 @@
+{
+    "version": "93.0.961.38",
+    "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+    "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+    },
+    "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+    "architecture": {
+        "64bit": {
+            "url": "https://msedgedriver.azureedge.net/93.0.961.38/edgedriver_win64.zip",
+            "hash": "407194c58ba05382db610d3fdb25dd5912dad675a0e3025e0a5c6c644e344ce1"
+        },
+        "32bit": {
+            "url": "https://msedgedriver.azureedge.net/93.0.961.38/edgedriver_win32.zip",
+            "hash": "cb93b26f75b2350bbf4f4315abe5f20a489415b6f3e548f96ff798409e6fe346"
+        }
+    },
+    "bin": "msedgedriver.exe",
+    "checkver": {
+        "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+            },
+            "32bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+            }
+        }
+    }
+}

--- a/googlechrome-93.json
+++ b/googlechrome-93.json
@@ -1,0 +1,51 @@
+{
+  "version": "93.0.4577.63",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/iqpk575b5oapeemzff6rvxw7qu_93.0.4577.63/93.0.4577.63_chrome_installer.exe#/dl.7z",
+      "hash": "ef94524844237aff02b318616b381ebc1683228377a38d2e7f68a879ba22fe7e"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/adqhpzhsm7durn7ptspnysfodmeq_93.0.4577.63/93.0.4577.63_chrome_installer.exe#/dl.7z",
+      "hash": "d7dd779ce45b631b2e64554fd998adb088b08e2496d030e40058e0ae35ea9d04"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://chrome-dl.com/api/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: https://chrome-dl.com/api/chrome.min.xml