### PR TITLE
TINY-8170: Added Google Chrome, chromedriver and edgedriver v95

### DIFF
--- a/chromedriver-95.json
+++ b/chromedriver-95.json
@@ -1,0 +1,17 @@
+{
+    "version": "95.0.4638.17",
+    "description": "An open source tool for automated testing of webapps across many browsers",
+    "homepage": "https://chromedriver.chromium.org/",
+    "license": "BSD-3-Clause",
+    "url": "https://chromedriver.storage.googleapis.com/95.0.4638.17/chromedriver_win32.zip",
+    "hash": "md5:9ac3dda7b4b5ebead789fa4e6efc483b",
+    "bin": "chromedriver.exe",
+    "checkver": "stable.*?([\\d.]+)<",
+    "autoupdate": {
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+        "hash": {
+            "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+            "regex": "$version/$basename.*?\"$md5\""
+        }
+    }
+}

--- a/edgedriver-95.json
+++ b/edgedriver-95.json
@@ -1,0 +1,35 @@
+{
+    "version": "95.0.1020.30",
+    "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+    "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+    },
+    "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+    "architecture": {
+        "64bit": {
+            "url": "https://msedgedriver.azureedge.net/95.0.1020.30/edgedriver_win64.zip",
+            "hash": "127c322b7530e19ad438c49feb3f30c878df7bd0802026ec8728b4a9fe2cdeac"
+        },
+        "32bit": {
+            "url": "https://msedgedriver.azureedge.net/95.0.1020.30/edgedriver_win32.zip",
+            "hash": "c9fe1becb0caca20c455a3cfb0a5e7c21e8e51bbc004cc02e648767c8ef6e7af"
+        }
+    },
+    "bin": "msedgedriver.exe",
+    "checkver": {
+        "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+            },
+            "32bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+            }
+        }
+    }
+}

--- a/googlechrome-95.json
+++ b/googlechrome-95.json
@@ -1,0 +1,51 @@
+{
+  "version": "95.0.4638.54",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/id4ma77on5veckrgwsrfbhgwda_95.0.4638.54/95.0.4638.54_chrome_installer.exe#/dl.7z",
+      "hash": "c753c1a71ef34c3bc6b5cbd59fb324c8b8dd9c99e21885a0fdacc4e145b0a584"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/cz6f6jwwxjzpszomeh6wjcm7my_95.0.4638.54/95.0.4638.54_chrome_installer.exe#/dl.7z",
+      "hash": "e8dfaae529534c934e975274e64e5602a999d3b82fea736a186ff7b470e846b4"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://chrome-dl.com/api/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: https://github.com/SukkaW/CheckChrome/ (old site is dead so have to run a script to get the version numbers)