### PR TITLE
TINY-8405: Added Google Chrome, chromedriver and edgedriver v97

### DIFF
--- a/chromedriver-97.json
+++ b/chromedriver-97.json
@@ -1,0 +1,17 @@
+{
+    "version": "97.0.4692.71",
+    "description": "An open source tool for automated testing of webapps across many browsers",
+    "homepage": "https://chromedriver.chromium.org/",
+    "license": "BSD-3-Clause",
+    "url": "https://chromedriver.storage.googleapis.com/97.0.4692.71/chromedriver_win32.zip",
+    "hash": "md5:58ac3bf76466773680a5fe04b69ad1d3",
+    "bin": "chromedriver.exe",
+    "checkver": "stable.*?([\\d.]+)<",
+    "autoupdate": {
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+        "hash": {
+            "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+            "regex": "$version/$basename.*?\"$md5\""
+        }
+    }
+}

--- a/edgedriver-97.json
+++ b/edgedriver-97.json
@@ -1,0 +1,35 @@
+{
+    "version": "97.0.1072.55",
+    "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+    "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+    },
+    "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+    "architecture": {
+        "64bit": {
+            "url": "https://msedgedriver.azureedge.net/97.0.1072.55/edgedriver_win64.zip",
+            "hash": "363956956c571de12f1371850c948a6da68d37a86746a0c90997f8804e5a2cb2"
+        },
+        "32bit": {
+            "url": "https://msedgedriver.azureedge.net/97.0.1072.55/edgedriver_win32.zip",
+            "hash": "f36323d1968cb143172f21b10459b5c1dae26be1d12cf3c2bb0d15eca83e6813"
+        }
+    },
+    "bin": "msedgedriver.exe",
+    "checkver": {
+        "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+            },
+            "32bit": {
+                "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+            }
+        }
+    }
+}

--- a/googlechrome-97.json
+++ b/googlechrome-97.json
@@ -1,0 +1,51 @@
+{
+  "version": "97.0.4692.71",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/gim2vp4vywbbfcpqxfzp3mfirq_97.0.4692.71/97.0.4692.71_chrome_installer.exe#/dl.7z",
+      "hash": "c2f68f2d05498920d3968a2914702a5529b0fb81f3b3bd89eaca904202bae9d2"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/ac2v7dyzan6jlpxotaeocdrzjlsq_97.0.4692.71/97.0.4692.71_chrome_installer.exe#/dl.7z",
+      "hash": "5163df13c2be65158ae03495e1a93a5dca14d78579c060c489b2f46a463c9620"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://chrome-dl.com/api/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: https://github.com/SukkaW/CheckChrome/ (old site is dead so have to run a script to get the version numbers)