### PR TITLE
TINY-8544: Added edgedriver, chromedriver and googlechrome v99

### DIFF
--- a/chromedriver-99.json
+++ b/chromedriver-99.json
@@ -1,0 +1,17 @@
+{
+  "version": "99.0.4844.51",
+  "description": "An open source tool for automated testing of webapps across many browsers",
+  "homepage": "https://chromedriver.chromium.org/",
+  "license": "BSD-3-Clause",
+  "url": "https://chromedriver.storage.googleapis.com/99.0.4844.51/chromedriver_win32.zip",
+  "hash": "md5:c42faa8f2d89fe5d3f3ba20658787144",
+  "bin": "chromedriver.exe",
+  "checkver": "stable.*?([\\d.]+)<",
+  "autoupdate": {
+      "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+      "hash": {
+          "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+          "regex": "$version/$basename.*?\"$md5\""
+      }
+  }
+}

--- a/edgedriver-99.json
+++ b/edgedriver-99.json
@@ -1,0 +1,35 @@
+{
+  "version": "99.0.1150.36",
+  "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+  "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  "license": {
+      "identifier": "Freeware",
+      "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+  },
+  "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+  "architecture": {
+      "64bit": {
+          "url": "https://msedgedriver.azureedge.net/99.0.1150.36/edgedriver_win64.zip",
+          "hash": "58164280edbe2017ac15348a988ebecb9349fe18454c67ac8d9377e13dd0d1a6"
+      },
+      "32bit": {
+          "url": "https://msedgedriver.azureedge.net/99.0.1150.36/edgedriver_win32.zip",
+          "hash": "c61b3291b097eb80ce8e14fcfa3e10b8a0e6fc60fa9b8e3e389e7e44e113a094"
+      }
+  },
+  "bin": "msedgedriver.exe",
+  "checkver": {
+      "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+      "regex": "([\\d.]+)"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+          },
+          "32bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+          }
+      }
+  }
+}

--- a/googlechrome-99.json
+++ b/googlechrome-99.json
@@ -1,0 +1,51 @@
+{
+  "version": "99.0.4844.51",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/adhm6j66jm36tzwpa6sldiyac6aq_99.0.4844.51/99.0.4844.51_chrome_installer.exe#/dl.7z",
+      "hash": "d81a9e6e9cfd73fe359659b849ebe59f270f371189b1c6c10e9d8486619e2911"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/gqczgg3uhy46ftenjszsfj5hcy_99.0.4844.51/99.0.4844.51_chrome_installer.exe#/dl.7z",
+      "hash": "203d502df7fa9c3da88582fec9db4fc1e8d56caaf382a8a4a95087423a9846de"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://chrome-dl.com/api/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://chrome-dl.com/api/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: 
      - Clone https://github.com/SukkaW/CheckChrome/
      - Comment out line 34 in the `run.sh` script
      - Execute the `run.sh` script (expect issues with directory doesn't exist)
      - Find the latest version in the `stable-x64.xml` and `stable-x86.xml` files