### PR TITLE
TINY-8656: Added Google Chrome, chromedriver and edgedriver v101

### DIFF
--- a/chromedriver-101.json
+++ b/chromedriver-101.json
@@ -1,0 +1,17 @@
+{
+  "version": "101.0.4951.41",
+  "description": "An open source tool for automated testing of webapps across many browsers",
+  "homepage": "https://chromedriver.chromium.org/",
+  "license": "BSD-3-Clause",
+  "url": "https://chromedriver.storage.googleapis.com/101.0.4951.41/chromedriver_win32.zip",
+  "hash": "md5:594669544f54e61c3762252d1a85f3d8",
+  "bin": "chromedriver.exe",
+  "checkver": "stable.*?([\\d.]+)<",
+  "autoupdate": {
+      "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+      "hash": {
+          "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+          "regex": "$version/$basename.*?\"$md5\""
+      }
+  }
+}

--- a/edgedriver-101.json
+++ b/edgedriver-101.json
@@ -1,0 +1,35 @@
+{
+  "version": "101.0.1210.32",
+  "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+  "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  "license": {
+      "identifier": "Freeware",
+      "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+  },
+  "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+  "architecture": {
+      "64bit": {
+          "url": "https://msedgedriver.azureedge.net/101.0.1210.32/edgedriver_win64.zip",
+          "hash": "b4f9c4a79e2b79a00041fde2d44b13fc8bd4b010c086fe5a2e2db569af532bcd"
+      },
+      "32bit": {
+          "url": "https://msedgedriver.azureedge.net/101.0.1210.32/edgedriver_win32.zip",
+          "hash": "7194f6552e6349f6f7ed86e811c7a36a0f971c491dfa8e65134e1754aa257dff"
+      }
+  },
+  "bin": "msedgedriver.exe",
+  "checkver": {
+      "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+      "regex": "([\\d.]+)"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+          },
+          "32bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+          }
+      }
+  }
+}

--- a/googlechrome-101.json
+++ b/googlechrome-101.json
@@ -1,0 +1,51 @@
+{
+  "version": "101.0.4951.41",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/adhsa4gplkf573nizk5shcj4dsfq_101.0.4951.41/101.0.4951.41_chrome_installer.exe#/dl.7z",
+      "hash": "a766ef7c9af7598cc021fd120fcaf52772237c7de7591a00e75485cc14647422"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/adnuzcfdd5hcbzuidzfp6h4fkx4q_101.0.4951.41/101.0.4951.41_chrome_installer.exe#/dl.7z",
+      "hash": "8a8087408e3142ae5b213838515b290e8b273b64f43cde224f40f6004e771e96"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version. I did update the googlechrome autoupdater configuration to use the new scoop update tracker though.

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml