### PR TITLE
TINY-8933: Upgraded to the latest v103 chromedriver/edgedriver to fix the driver crashing

### DIFF
--- a/chromedriver-103.json
+++ b/chromedriver-103.json
@@ -1,10 +1,10 @@
 {
-  "version": "103.0.5060.53",
+  "version": "103.0.5060.134",
   "description": "An open source tool for automated testing of webapps across many browsers",
   "homepage": "https://chromedriver.chromium.org/",
   "license": "BSD-3-Clause",
-  "url": "https://chromedriver.storage.googleapis.com/103.0.5060.53/chromedriver_win32.zip",
-  "hash": "md5:797244dcadc6012093c8955463c1c949",
+  "url": "https://chromedriver.storage.googleapis.com/103.0.5060.134/chromedriver_win32.zip",
+  "hash": "md5:79550cec2dbeb099216b3b756af188b8",
   "bin": "chromedriver.exe",
   "checkver": "stable.*?([\\d.]+)<",
   "autoupdate": {

--- a/edgedriver-103.json
+++ b/edgedriver-103.json
@@ -1,5 +1,5 @@
 {
-  "version": "103.0.1264.37",
+  "version": "103.0.1264.71",
   "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
   "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
   "license": {
@@ -9,12 +9,12 @@
   "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
   "architecture": {
       "64bit": {
-          "url": "https://msedgedriver.azureedge.net/103.0.1264.37/edgedriver_win64.zip",
-          "hash": "282f1f3cf668e313df49207a77549883386886d7566ac93b9d4ce327ccbe7e3e"
+          "url": "https://msedgedriver.azureedge.net/103.0.1264.71/edgedriver_win64.zip",
+          "hash": "0ef06eda12bc094201190b91c03a48c8b72c97f3be96e4cc12363405f09bbe35"
       },
       "32bit": {
-          "url": "https://msedgedriver.azureedge.net/103.0.1264.37/edgedriver_win32.zip",
-          "hash": "8b8bbb21936a1c18fc1c1f9df8d258745aac20842a410db8fff577a5f70d7de4"
+          "url": "https://msedgedriver.azureedge.net/103.0.1264.71/edgedriver_win32.zip",
+          "hash": "0a56ae7d8bf8cd3d37e10875400dec835d62d02636e66bfc2af2691736c8f1bf"
       }
   },
   "bin": "msedgedriver.exe",


### PR DESCRIPTION
This just upgrades to the latest v103 drivers to fix tests randomly crashing due to https://bugs.chromium.org/p/chromedriver/issues/detail?id=4121

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads