### PR TITLE
DEVOPS-529: Added Google Chrome, chromedriver and edgedriver v105

### DIFF
--- a/chromedriver-105.json
+++ b/chromedriver-105.json
@@ -1,0 +1,17 @@
+{
+  "version": "105.0.5195.52",
+  "description": "An open source tool for automated testing of webapps across many browsers",
+  "homepage": "https://chromedriver.chromium.org/",
+  "license": "BSD-3-Clause",
+  "url": "https://chromedriver.storage.googleapis.com/105.0.5195.52/chromedriver_win32.zip",
+  "hash": "md5:b316999de7e856721f87438c3e870295",
+  "bin": "chromedriver.exe",
+  "checkver": "stable.*?([\\d.]+)<",
+  "autoupdate": {
+      "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+      "hash": {
+          "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+          "regex": "$version/$basename.*?\"$md5\""
+      }
+  }
+}

--- a/edgedriver-105.json
+++ b/edgedriver-105.json
@@ -1,0 +1,35 @@
+{
+  "version": "105.0.1343.27",
+  "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+  "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  "license": {
+      "identifier": "Freeware",
+      "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+  },
+  "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+  "architecture": {
+      "64bit": {
+          "url": "https://msedgedriver.azureedge.net/105.0.1343.27/edgedriver_win64.zip",
+          "hash": "5c97c4a7eb785913ebd2c1fc8c91a639e5a2d1ef5633a13904fee5f7213fa31d"
+      },
+      "32bit": {
+          "url": "https://msedgedriver.azureedge.net/105.0.1343.27/edgedriver_win32.zip",
+          "hash": "5b7098079f7a8e38eeb9d3698ce64392718192e374c8741b270ec35c78ab3ce2"
+      }
+  },
+  "bin": "msedgedriver.exe",
+  "checkver": {
+      "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+      "regex": "([\\d.]+)"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+          },
+          "32bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+          }
+      }
+  }
+}

--- a/googlechrome-105.json
+++ b/googlechrome-105.json
@@ -1,0 +1,51 @@
+{
+  "version": "105.0.5195.102",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/fdxizo4c4cqsdov54q2nste54u_105.0.5195.102/105.0.5195.102_chrome_installer.exe#/dl.7z",
+      "hash": "c7d6b85253d9c4868012a7d056a592ba6179bc4e4e8ff261f926e5750eb5d8f8"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/ac5fmvm3onpyw7fsckmcbaek3z3q_105.0.5195.102/105.0.5195.102_chrome_installer.exe#/dl.7z",
+      "hash": "1aad19d9e743da1af3b28c3c8025090134adcd2a9e056d271f24a98538c3b528"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version. I did update the googlechrome autoupdater configuration to use the new scoop update tracker though.

Versions/URLs were fetched from:
- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml