### PR TITLE
DEVOPS-728: Added chromedriver v111

### DIFF
--- a/chromedriver-111.json
+++ b/chromedriver-111.json
@@ -1,0 +1,17 @@
+{
+    "version": "111.0.5563.64",
+    "description": "An open source tool for automated testing of webapps across many browsers",
+    "homepage": "https://chromedriver.chromium.org/",
+    "license": "BSD-3-Clause",
+    "url": "https://chromedriver.storage.googleapis.com/111.0.5563.64/chromedriver_win32.zip",
+    "hash": "md5:1ab9bad13ad569d982302e7e4da63d6c",
+    "bin": "chromedriver.exe",
+    "checkver": "stable.*?([\\d.]+)<",
+    "autoupdate": {
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+        "hash": {
+            "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+            "regex": "$version/$basename.*?\"$md5\""
+        }
+    }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Based current version on Scoop main: https://github.com/ScoopInstaller/Main/blob/master/bucket/chromedriver.json