### PR TITLE
DEVOPS-728: Google Chrome update to 111

### DIFF
--- a/googlechrome-111.json
+++ b/googlechrome-111.json
@@ -1,0 +1,51 @@
+{
+  "version": "111.0.5563.65",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/adnqciwe4zwyf6mady3hdofbomva_111.0.5563.65/111.0.5563.65_chrome_installer.exe#/dl.7z",
+      "hash": "29d96849b9c990d2d4baa77ba26b1574876777b6f08308066765e325c521b16e"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/flle6rkdjvbtoxe4dab62di2f4_111.0.5563.65/111.0.5563.65_chrome_installer.exe#/dl.7z",
+      "hash": "5caddd4bd26cb5cb9222ce20a9c273c76aee8e16d0a321fdbda90a7c05bbf35c"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Versions/URLs were fetched from:

- Google Chrome: https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml (out of date so manually re-run from https://github.com/ScoopInstaller/UpdateTracker)