### PR TITLE
DEVOPS-756: Update Chrome/Edge

### DIFF
--- a/chromedriver-112.json
+++ b/chromedriver-112.json
@@ -1,0 +1,17 @@
+{
+    "version": "111.0.5563.64",
+    "description": "An open source tool for automated testing of webapps across many browsers",
+    "homepage": "https://chromedriver.chromium.org/",
+    "license": "BSD-3-Clause",
+    "url": "https://chromedriver.storage.googleapis.com/112.0.5615.49/chromedriver_win32.zip",
+    "hash": "md5:3aa0e2c3dca02a93422152248411c964",
+    "bin": "chromedriver.exe",
+    "checkver": "stable.*?([\\d.]+)<",
+    "autoupdate": {
+        "url": "https://chromedriver.storage.googleapis.com/$version/chromedriver_win32.zip",
+        "hash": {
+            "url": "https://chromedriver.storage.googleapis.com/?prefix=$version/",
+            "regex": "$version/$basename.*?\"$md5\""
+        }
+    }
+}

--- a/edgedriver-112.json
+++ b/edgedriver-112.json
@@ -1,0 +1,35 @@
+{
+  "version": "112.0.1722.39",
+  "description": "Close the loop on your developer cycle by automating testing of your website in Microsoft Edge (Chromium).",
+  "homepage": "https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
+  "license": {
+      "identifier": "Freeware",
+      "url": "https://az813057.vo.msecnd.net/webdriver/license.html"
+  },
+  "notes": "For legacy (EdgeHTML) version, see 'versions/edgedriver-legacy'.",
+  "architecture": {
+      "64bit": {
+          "url": "https://msedgedriver.azureedge.net/112.0.1722.39/edgedriver_win64.zip",
+          "hash": "0d68705e8258567dc4fe1160eb0b066e988e641de99e87e6c06380b15cedb180"
+      },
+      "32bit": {
+          "url": "https://msedgedriver.azureedge.net/112.0.1722.39/edgedriver_win32.zip",
+          "hash": "b17cfb0165b34e89d175e55f1358915edf4c23624a76b1d118034b241ad7d881"
+      }
+  },
+  "bin": "msedgedriver.exe",
+  "checkver": {
+      "url": "https://msedgedriver.azureedge.net/LATEST_STABLE",
+      "regex": "([\\d.]+)"
+  },
+  "autoupdate": {
+      "architecture": {
+          "64bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win64.zip"
+          },
+          "32bit": {
+              "url": "https://msedgedriver.azureedge.net/$version/edgedriver_win32.zip"
+          }
+      }
+  }
+}

--- a/googlechrome-112.json
+++ b/googlechrome-112.json
@@ -1,0 +1,51 @@
+{
+  "version": "112.0.5615.50",
+  "description": "Fast, secure, and free web browser, built for the modern web.",
+  "homepage": "https://www.google.com/chrome/",
+  "license": {
+    "identifier": "Freeware",
+    "url": "https://www.google.com/chrome/privacy/eula_text.html"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://dl.google.com/release2/chrome/alqo5mt5gnkjmd5dl2b6ca74ve_112.0.5615.50/112.0.5615.50_chrome_installer.exe#/dl.7z",
+      "hash": "6bbe800cdb2de9d73668413493da1e85ae57f2f09752d99253eeac6e39b4cc89"
+    },
+    "32bit": {
+      "url": "https://dl.google.com/release2/chrome/adzewuql6f5tv76cyhh65msm5z6q_112.0.5615.50/112.0.5615.50_chrome_installer.exe#/dl.7z",
+      "hash": "f274c4131ada5707247f343d2953aa5aea0aa2ae6bce11a185bc2b872f87278f"
+    }
+  },
+  "installer": {
+    "script": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal"
+  },
+  "bin": "chrome.exe",
+  "shortcuts": [
+    [
+      "chrome.exe",
+      "Google Chrome"
+    ]
+  ],
+  "checkver": {
+    "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+    "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable64[version='$version']/sha256"
+        }
+      },
+      "32bit": {
+        "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
+        "hash": {
+          "url": "https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml",
+          "xpath": "/chromechecker/stable32[version='$version']/sha256"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This just copies the old files and updates the version, url and hashes to match the new version.

Versions/URLs were fetched from:

- edgedriver: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
- chromedriver: https://chromedriver.chromium.org/downloads
- Google Chrome: https://scoopinstaller.github.io/UpdateTracker/googlechrome/chrome.min.xml